### PR TITLE
design: '테마 랭킹' 페이지, 생성 및 연결 (#24)

### DIFF
--- a/lib/screens/ranking/ranking.dart
+++ b/lib/screens/ranking/ranking.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:app/screens/ranking/themeRanking.dart';
 import 'package:flutter/material.dart';
 
 class Ranking extends StatefulWidget {
@@ -13,26 +14,32 @@ class _RankingState extends State<Ranking> {
 
   dynamic itemList = [
     {
+      "themeCode": 0,
       "image" : "assets/images/mockimg1.jpg",
       "theme" : "전체",
     },
     {
+      "themeCode": 1,
       "image" : "assets/images/mockimg2.jpg",
       "theme" : "카페",
     },
     {
+      "themeCode": 2,
       "image" : "assets/images/mockimg3.jpg",
       "theme" : "익스트림",
     },
     {
+      "themeCode": 3,
       "image" : "assets/images/mockimg3.jpg",
       "theme" : "쏼라쏼라",
     },
     {
+      "themeCode": 4,
       "image" : "assets/images/mockimg2.jpg",
       "theme" : "저쩌구",
     },
     {
+      "themeCode": 5,
       "image" : "assets/images/mockimg1.jpg",
       "theme" : "어쩌그",
     },
@@ -178,32 +185,41 @@ class _RankingState extends State<Ranking> {
               // 화면에 표시될 위젯을 설정
               delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
-                  return Container(
-                    padding: EdgeInsets.all(0.5),
-                    decoration: BoxDecoration(
+                  return InkWell(
+                    onTap: () {
+                      Navigator.push(context, MaterialPageRoute(builder: (context) => themeRanking(
+                        themeCode: itemList[index]["themeCode"],
+                        image: itemList[index]["image"],
+                        theme: itemList[index]["theme"]))
+                      );
+                    },
+                    child: Container(
+                      padding: EdgeInsets.all(0.5),
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          image: DecorationImage(
+                              image: AssetImage(itemList[index]["image"]),
+                              fit: BoxFit.cover)
+                      ),
+                      child: ClipRRect(
                         borderRadius: BorderRadius.circular(10),
-                        image: DecorationImage(
-                            image: AssetImage(itemList[index]["image"]),
-                            fit: BoxFit.cover)
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(10),
-                      child: BackdropFilter(
-                        filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
-                        child: Container(
-                          alignment: Alignment.center,
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                itemList[index]['theme'],
-                                style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.bold
+                        child: BackdropFilter(
+                          filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
+                          child: Container(
+                            alignment: Alignment.center,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  itemList[index]['theme'],
+                                  style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.bold
+                                  ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/screens/ranking/themeRanking.dart
+++ b/lib/screens/ranking/themeRanking.dart
@@ -1,0 +1,71 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class themeRanking extends StatefulWidget {
+  const themeRanking({
+    required this.themeCode,
+    required this.image,
+    required this.theme,
+  });
+
+  final int themeCode;
+  final String image;
+  final String theme;
+
+  @override
+  State<themeRanking> createState() => _themeRankingState();
+}
+
+class _themeRankingState extends State<themeRanking> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: const Icon(Icons.arrow_back),
+        ),
+        title: const Text("테마 랭킹", style: TextStyle(color: Colors.black, fontSize: 16),),
+      ),
+      body: Column(
+        children: [
+          Text(widget.themeCode.toString()),
+          Container(
+            padding: EdgeInsets.all(0.5),
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                image: DecorationImage(
+                    image: AssetImage(widget.image),
+                    fit: BoxFit.cover)
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(10),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
+                child: Container(
+                  alignment: Alignment.center,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        widget.theme,
+                        style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
'설정 랭킹 (#4)'에서

혹시 추가로 작업하실 게 있으실 때

이번 커밋 내용과 충돌을 일으킬 수도 있을까봐

이것부터 미리 머지하려고 합니다.

# 변경 내용 설명

![image](https://github.com/Trip-To-Travel/TTT-front/assets/53112143/d6b577ae-00b9-4948-83db-113bba146dc4)

나중에 '테마 랭킹'에서 관련 query를 날려줄 때 유용하게 사용될 `themeCode`가 필요할 것 같아서 임의로 추가해 보았습니다.

---

![image](https://github.com/Trip-To-Travel/TTT-front/assets/53112143/39643172-b85f-4c5c-856d-57676d609fd4)

이런식으로 '테마 랭킹' 페이지(Stateful 위젯)에 데이터를 넘겨줍니다.

각 컴포넌트?가 버튼으로써 동작할 수 있도록 `InkWell` 위젯으로 한 번 감싸주었습니다.

---

![image](https://github.com/Trip-To-Travel/TTT-front/assets/53112143/0d48cf86-5f8e-49be-94e9-17f40b399825)

이런 식으로 넘겨받아 사용 가능함을 확인했습니다.